### PR TITLE
Allow custom route function

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -226,7 +226,7 @@ const getRouteInput = (
       method = methodArg.text
       path = pathArg.text
 
-      // Property access chain ends
+      // Done
       break
     } else if (ts.isPropertyAccessExpression(lhs)) {
       if (!ts.isIdentifier(lhs.name)) return
@@ -243,6 +243,9 @@ const getRouteInput = (
           return
         }
         path = pathArg.text
+
+        // Done
+        break
       } else if (fnName === 'handler') {
         const handlerFn = expr.arguments[0]
         if (

--- a/tests/__snapshots__/generate.spec.ts.snap
+++ b/tests/__snapshots__/generate.spec.ts.snap
@@ -390,6 +390,22 @@ Array [
           },
         },
       },
+      "/uses-custom-route": Object {
+        "get": Object {
+          "responses": Object {
+            "200": Object {
+              "content": Object {
+                "text/plain": Object {
+                  "schema": Object {
+                    "type": "string",
+                  },
+                },
+              },
+              "description": "200",
+            },
+          },
+        },
+      },
     },
   },
 ]

--- a/tests/test-routes.ts
+++ b/tests/test-routes.ts
@@ -1,4 +1,11 @@
-import { Parser, Response, Route, route, router } from 'typera-express'
+import {
+  applyMiddleware,
+  Parser,
+  Response,
+  Route,
+  route,
+  router,
+} from 'typera-express'
 import * as t from 'io-ts'
 import { IntFromString, NumberFromString } from 'io-ts-types'
 
@@ -140,6 +147,14 @@ const responseHeaders: Route<
   return Response.ok('yep', { 'X-Foo': 'foo', 'X-Bar': 'bar' })
 })
 
+// Custom route function
+const customRoute = () => applyMiddleware()
+const usesCustomRoute: Route<Response.Ok<string>> = customRoute()
+  .get('/uses-custom-route')
+  .handler(async () => {
+    return Response.ok('foo')
+  })
+
 export default router(
   constant,
   directRouteCall,
@@ -151,5 +166,6 @@ export default router(
   query,
   routeParams,
   brandedRequestBody,
-  responseHeaders
+  responseHeaders,
+  usesCustomRoute
 )


### PR DESCRIPTION
Stop searching for method and path when they're found. This allows the `route` constructor to be returned from a custom function because now we don't try to interpret the custom function's parameters.