### PR TITLE
Support non-inline route handlers

### DIFF
--- a/tests/__snapshots__/generate.spec.ts.snap
+++ b/tests/__snapshots__/generate.spec.ts.snap
@@ -165,6 +165,49 @@ Array [
           },
         },
       },
+      "/handler-not-inline": Object {
+        "post": Object {
+          "requestBody": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "foo": Object {
+                      "type": "string",
+                    },
+                  },
+                  "required": Array [
+                    "foo",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+          },
+          "responses": Object {
+            "200": Object {
+              "content": Object {
+                "text/plain": Object {
+                  "schema": Object {
+                    "type": "string",
+                  },
+                },
+              },
+              "description": "OK",
+            },
+            "400": Object {
+              "content": Object {
+                "text/plain": Object {
+                  "schema": Object {
+                    "type": "string",
+                  },
+                },
+              },
+              "description": "Bad Request",
+            },
+          },
+        },
+      },
       "/interface-array-response": Object {
         "get": Object {
           "responses": Object {

--- a/tests/test-routes.ts
+++ b/tests/test-routes.ts
@@ -229,6 +229,20 @@ const samePathRoute2: Route<Response.Ok<{ bar: number }>> = route
   .post('/same-path-route')
   .handler(async () => Response.ok({ bar: 42 }))
 
+// Route handler not inline
+
+const nonInlineHandler = () => {
+  return Response.ok('hello')
+}
+
+const handlerNotInline: Route<
+  Response.Ok<string> | Response.BadRequest<string>
+> = route
+  .post('/handler-not-inline')
+  // The handler doesn't use the body, but it should still be in the openapi defs
+  .use(Parser.body(t.type({ foo: t.string })))
+  .handler(nonInlineHandler)
+
 export default router(
   constant,
   directRouteCall,
@@ -247,5 +261,6 @@ export default router(
   schemaDocstrings,
   binaryResponse,
   samePathRoute1,
-  samePathRoute2
+  samePathRoute2,
+  handlerNotInline
 )


### PR DESCRIPTION
Don't use the type of the route handler function itself to find out the request type. Instead, inspect the `RouteConstructor` type, and find the type of the request passed to the route handler.

Fixes #123 