### PR TITLE
Support aliased route types

### DIFF
--- a/tests/__snapshots__/generate.spec.ts.snap
+++ b/tests/__snapshots__/generate.spec.ts.snap
@@ -608,6 +608,32 @@ Array [
           },
         },
       },
+      "/type-alias": Object {
+        "get": Object {
+          "responses": Object {
+            "200": Object {
+              "content": Object {
+                "text/plain": Object {
+                  "schema": Object {
+                    "type": "string",
+                  },
+                },
+              },
+              "description": "OK",
+            },
+            "400": Object {
+              "content": Object {
+                "text/plain": Object {
+                  "schema": Object {
+                    "type": "string",
+                  },
+                },
+              },
+              "description": "Bad Request",
+            },
+          },
+        },
+      },
       "/unused-request": Object {
         "get": Object {
           "responses": Object {

--- a/tests/test-routes.ts
+++ b/tests/test-routes.ts
@@ -243,6 +243,17 @@ const handlerNotInline: Route<
   .use(Parser.body(t.type({ foo: t.string })))
   .handler(nonInlineHandler)
 
+// Route type is a type alias
+type GetHandler = Route<Response.Ok<string> | Response.BadRequest<string>>
+
+const typeAlias: GetHandler = route.get('/type-alias').handler(() => {
+  if (Math.random() > 0.5) {
+    return Response.ok('foo')
+  } else {
+    return Response.badRequest('bar')
+  }
+})
+
 export default router(
   constant,
   directRouteCall,
@@ -262,5 +273,6 @@ export default router(
   binaryResponse,
   samePathRoute1,
   samePathRoute2,
-  handlerNotInline
+  handlerNotInline,
+  typeAlias
 )


### PR DESCRIPTION
Dig the `Response` type from properties of the `Route` type instead of its type parameters, which are not available if the `Route` type is aliased to some other name.

Fixes #130 