### PR TITLE
Update to TypeScript 4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "openapi-types": "^9.0.0",
     "statuses": "^2.0.1",
-    "typescript": "^4.1.3",
+    "typescript": ">=4.3.0",
     "yargs": "^17.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3941,10 +3941,10 @@ typera-express@^2.4.0:
     express ">=4.0.0"
     typera-common "^2.4.1"
 
-typescript@^4.1.3:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
-  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+typescript@>=4.3.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
+  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
 
 underscore@~1.10.2:
   version "1.10.2"


### PR DESCRIPTION
If you're still using TypeScript 4.2 or newer, your routes will be typechecked and introspected with a newer TypeScript version. This shouldn't break anything as TypeScript is generally backwards compatible.