### PR TITLE
Resolve relative file paths to absolute paths.

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,7 +51,7 @@ const outputFileName = (sourceFileName: string, ext: string): string =>
 const main = async () => {
   const args = parseArgs()
 
-  const sourceFiles = args._.map((x) => x.toString())
+  const sourceFiles = args._.map((x) => path.resolve(x.toString()))
   const ext = `.openapi.${args.format}`
 
   const compilerOptions = readCompilerOptions(args.tsconfig)


### PR DESCRIPTION
The TypeScript compiler converts some paths to be absolute, which causes
.openapi.ts files to not be generated for all files.