### PR TITLE
BREAKING: Use components object and reference objects

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,4 +22,5 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: yarn
     - run: yarn lint
+    - run: yarn build
     - run: yarn test

--- a/README.md
+++ b/README.md
@@ -62,7 +62,12 @@ const myRoute: Route<Response.Ok<MyResult> | Response.BadRequest<string>> =
 
 // ...
 
+/**
+ * @prefix /api
+ */
 export default router(myRoute, ...)
+
+// The optional @prefix JSDoc tag prepends the prefix to all route paths.
 ```
 
 Run the `typera-openapi` tool giving paths to your route files as command line

--- a/README.md
+++ b/README.md
@@ -115,14 +115,11 @@ typera-openapi [options] FILE...
 
 Generate OpenAPI definitions for routes found in the given files.
 
-For each input file `file.ts`, writes a `file.openapi.ts` or
-`file.openapi.json`, depending on `--format`.
-
 Options:
 
-`--format`
+`-o OUTFILE`, `--outfile OUTFILE`
 
-Output file format. Either `ts` or `json`. Default: `ts`.
+Output file name. Must end in either `.ts` or `.json`.
 
 `--prettify`, `-p`
 
@@ -130,8 +127,8 @@ Apply [prettier] formatting to output files.
 
 `--check`, `-c`
 
-Check that generated files are up-to-date without actually generating them. If
-any file is outdated, print an error and exit with status 1. Useful for CI.
+Check that the output file is up-to-date without actually writing it. If the
+file is outdated, print an error and exit with status 1. Useful for CI.
 
 ## How it works?
 
@@ -234,6 +231,9 @@ For each route, typera-openapi determines the following information:
 | parameters   | See table below                                    |
 | request body | See table below                                    |
 | responses    | See table below                                    |
+
+Additionally, if the parent `router()` call has a `@prefix` tag in the JSDoc
+comment, it's prepended to the path of each of the routes.
 
 OpenAPI parameters covers all the other input expect the request body:
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 `typera-openapi` is an tool that automatically creates [OpenAPI v3] definitions
 for projects that use [typera] for routes.
 
+Upgrading to v2? See the [upgrading instructions](docs/upgrading.md).
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ import * as swaggerUi from 'swagger-ui-express'
 import { prefix } from 'typera-openapi'
 
 import myRoutes from './my-routes'
-import myRouteDefs from './my-routes.openapi'
+import openapi from './openapi'
 
 const openapiDoc: OpenAPIV3.Document = {
   openapi: '3.0.0',
@@ -91,9 +91,7 @@ const openapiDoc: OpenAPIV3.Document = {
     title: 'My cool API',
     version: '0.1.0',
   },
-  paths: {
-    ...prefix('/api', myRouteDefs.paths),
-  },
+  ...openapi,
 }
 
 const app = express()
@@ -101,9 +99,6 @@ app.use('/api', myRoutes.handler())
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(openapiDoc))
 app.listen(3000)
 ```
-
-The `prefix` function is used to move OpenAPI path definitions to a different
-prefix, because the `myRoutes` are served from the `/api` prefix.
 
 ## CLI
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,82 @@
+# Upgrading from v1 to v2
+
+In v1, typera-openapi generated one file per source file. In v2, all the OpenAPI
+stuff is put to a single file.
+
+Why? Because starting from v2, typera-openapi generates the schemas from
+`interface` and `type` alias object types under `components` and uses
+`"$ref": "#/components/schemas/TypeName"`. This results in a more concise
+output, sometimes more readable API documentation for the end user, and supports
+types that are defined recursively (i.e. reference themselves directly or
+indirectly).
+
+## Upgrading the CLI options
+
+_Use the `-o`/`--outfile` option to write to a specific file._ The default is
+`openapi.ts` in the working directory.
+
+Old:
+
+```
+$ typera-openapi src/routes1.ts src/routes2.ts
+```
+
+New:
+
+```
+$ typera-openapi -o src/openapi.ts src/routes1.ts src/routes2.ts
+```
+
+_Remove the `--format` option._ The output format is selected by the output file
+suffix. `.ts` writes TypeScript, `.json` writes JSON.
+
+Old:
+
+```
+$ typera-openapi --format json src/routes1.ts src/routes2.ts
+```
+
+New:
+
+```
+$ typera-openapi -o src/openapi.json src/routes1.ts src/routes2.ts
+```
+
+## Upgrading your code
+
+Because the output is in a single file, there's no need to merge paths objects
+anymore.
+
+Old:
+
+```
+import routeDefs from './routes.openapi'
+import otherDefs from './others.openapi'
+
+const openapiDoc: OpenAPIV3.Document = {
+  openapi: '3.0.0',
+  info: {
+    title: 'My cool API',
+    version: '0.1.0',
+  },
+  paths: {
+    ...routeDefs.paths,
+    ...otherDefs.paths
+  }
+}
+```
+
+New:
+
+```
+import openapi from './openapi'
+
+const openapiDoc: OpenAPIV3.Document = {
+  openapi: '3.0.0',
+  info: {
+    title: 'My cool API',
+    version: '0.1.0',
+  },
+  ...openapi,
+}
+```

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -60,13 +60,27 @@ const openapiDoc: OpenAPIV3.Document = {
     version: '0.1.0',
   },
   paths: {
-    ...routeDefs.paths,
-    ...otherDefs.paths
+    ...prefix('/api', routeDefs.paths),
+    ...prefix('/other', otherDefs.paths),
   }
 }
 ```
 
 New:
+
+Use the `@prefix` JSDoc tag to move routes to a different prefix:
+
+`routes.ts`
+
+```
+/**
+ * @prefix /api
+ */
+export default router(myRoute, ...)
+```
+
+The file that has the final OpenAPI document doesn't need to use the `prefix`
+function anymore:
 
 ```
 import openapi from './openapi'

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "typera-openapi": "./dist/cli.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
     "lint": "eslint --max-warnings 0 '**/*.ts' && prettier --check \"**/*.{json,md}\"",
     "lint:fix": "eslint --fix '**/*.ts' && prettier --write '**/*.{json,md}'",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,8 +69,11 @@ const main = async () => {
   }))
 
   let success = true
-  for (const { outputFileName, paths } of results) {
-    let content = args.format === 'ts' ? tsString(paths) : jsonString(paths)
+  for (const { outputFileName, paths, components } of results) {
+    let content =
+      args.format === 'ts'
+        ? tsString(paths, components)
+        : jsonString(paths, components)
     if (args.prettify) {
       content = await runPrettier(outputFileName, content)
     }
@@ -133,15 +136,22 @@ const writeOutput = (fileName: string, content: string): void => {
   fs.writeFileSync(fileName, content)
 }
 
-const tsString = (paths: OpenAPIV3.PathsObject): string => `\
+const tsString = (
+  paths: OpenAPIV3.PathsObject,
+  components: OpenAPIV3.ComponentsObject
+): string => `\
 import { OpenAPIV3 } from 'openapi-types'
 
-const spec: { paths: OpenAPIV3.PathsObject } = ${JSON.stringify({ paths })};
+const spec: { paths: OpenAPIV3.PathsObject, components: OpenAPIV3.ComponentsObject } = ${JSON.stringify(
+  { paths, components }
+)};
 
 export default spec;
 `
 
-const jsonString = (paths: OpenAPIV3.PathsObject): string =>
-  JSON.stringify({ paths })
+const jsonString = (
+  paths: OpenAPIV3.PathsObject,
+  components: OpenAPIV3.ComponentsObject
+): string => JSON.stringify({ paths, components })
 
 main()

--- a/src/components.ts
+++ b/src/components.ts
@@ -40,7 +40,7 @@ export class Components {
         return schema
       }
     } else {
-      return run(() => {})
+      return run(() => undefined)
     }
   }
 

--- a/src/components.ts
+++ b/src/components.ts
@@ -1,0 +1,96 @@
+import * as ts from 'typescript'
+import { OpenAPIV3 } from 'openapi-types'
+import { isInterface, isTypeAlias } from './utils'
+
+export class Components {
+  // undefined acts as a placeholder
+  #schemas: Map<string, OpenAPIV3.SchemaObject | undefined>
+  #symbolSchemas: Map<ts.Symbol, string>
+
+  constructor() {
+    this.#schemas = new Map()
+    this.#symbolSchemas = new Map()
+  }
+
+  withSymbol(
+    symbol: ts.Symbol | undefined,
+    run: (
+      addComponent: () => void
+    ) => OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject | undefined
+  ): OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject | undefined {
+    const ref = symbol && this.#getRefForSymbol(symbol)
+    if (ref) {
+      return { $ref: ref }
+    }
+
+    if (symbol && (isInterface(symbol) || isTypeAlias(symbol))) {
+      let added = false
+      const schema = run(() => {
+        this.#addSymbol(symbol)
+        added = true
+      })
+      if (added) {
+        if (schema === undefined || '$ref' in schema) {
+          this.#deleteSymbol(symbol)
+          return schema
+        } else {
+          return { $ref: this.#addSchema(symbol, schema) }
+        }
+      } else {
+        return schema
+      }
+    } else {
+      return run(() => {})
+    }
+  }
+
+  #getRefForSymbol(symbol: ts.Symbol): string | undefined {
+    const schemaName = this.#symbolSchemas.get(symbol)
+    return schemaName !== undefined
+      ? `#/components/schemas/${schemaName}`
+      : undefined
+  }
+
+  #addSymbol(symbol: ts.Symbol) {
+    if (this.#symbolSchemas.has(symbol)) return
+
+    let name = symbol.name
+    for (let i = 2; ; i++) {
+      if (this.#schemas.has(name)) {
+        name = `${symbol.name}${i}`
+      } else {
+        break
+      }
+    }
+
+    this.#schemas.set(name, undefined)
+    this.#symbolSchemas.set(symbol, name)
+  }
+
+  #deleteSymbol(symbol: ts.Symbol) {
+    const name = this.#symbolSchemas.get(symbol)
+    if (name === undefined) return
+
+    this.#schemas.delete(name)
+    this.#symbolSchemas.delete(symbol)
+  }
+
+  #addSchema(symbol: ts.Symbol, schema: OpenAPIV3.SchemaObject): string {
+    const name = this.#symbolSchemas.get(symbol)
+    if (name === undefined)
+      throw new Error(`No schema has been added for symbol ${symbol.name}`)
+    this.#schemas.set(name, schema)
+    return `#/components/schemas/${name}`
+  }
+
+  build(): OpenAPIV3.ComponentsObject {
+    const schemas = Object.fromEntries(
+      [...this.#schemas.entries()].flatMap(([k, v]) =>
+        v !== undefined ? [[k, v]] : []
+      )
+    )
+    return {
+      ...(this.#schemas.size > 0 ? { schemas } : undefined),
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { generate } from './generate'
+export { GenerateResult, generate } from './generate'
 export { LogLevel } from './context'
 import { OpenAPIV3 } from 'openapi-types'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,2 @@
 export { GenerateResult, generate } from './generate'
 export { LogLevel } from './context'
-import { OpenAPIV3 } from 'openapi-types'
-
-export const prefix = (
-  prefix: string,
-  paths: OpenAPIV3.PathsObject
-): OpenAPIV3.PathsObject =>
-  Object.fromEntries(
-    Object.entries(paths).map(([path, value]) => [prefix + path, value])
-  )

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,6 +28,10 @@ export const isUndefinedType = (type: ts.Type): boolean =>
   !!(type.flags & ts.TypeFlags.Undefined)
 export const isNullType = (type: ts.Type): boolean =>
   !!(type.flags & ts.TypeFlags.Null)
+export const isInterface = (symbol: ts.Symbol): boolean =>
+  !!(symbol.flags & ts.SymbolFlags.Interface)
+export const isTypeAlias = (symbol: ts.Symbol): boolean =>
+  !!(symbol.flags & ts.SymbolFlags.TypeAlias)
 
 // Check for a specific object type based on type name and property names
 const duckTypeChecker =

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,9 +28,9 @@ export const isUndefinedType = (type: ts.Type): boolean =>
   !!(type.flags & ts.TypeFlags.Undefined)
 export const isNullType = (type: ts.Type): boolean =>
   !!(type.flags & ts.TypeFlags.Null)
-export const isInterface = (symbol: ts.Symbol): boolean =>
+export const isInterface = (symbol: ts.Symbol): boolean =>
   !!(symbol.flags & ts.SymbolFlags.Interface)
-export const isTypeAlias = (symbol: ts.Symbol): boolean =>
+export const isTypeAlias = (symbol: ts.Symbol): boolean =>
   !!(symbol.flags & ts.SymbolFlags.TypeAlias)
 
 // Check for a specific object type based on type name and property names

--- a/tests/__snapshots__/generate.spec.ts.snap
+++ b/tests/__snapshots__/generate.spec.ts.snap
@@ -399,7 +399,7 @@ Object {
         },
       },
     },
-    "/other-route": Object {
+    "/other-stuff/other-route": Object {
       "get": Object {
         "responses": Object {
           "200": Object {

--- a/tests/__snapshots__/generate.spec.ts.snap
+++ b/tests/__snapshots__/generate.spec.ts.snap
@@ -11,230 +11,485 @@ Array [
 `;
 
 exports[`generate works 1`] = `
-Array [
-  Object {
-    "components": Object {
-      "schemas": Object {
-        "DirectRecursiveIntersection": Object {
-          "properties": Object {
-            "children": Object {
-              "$ref": "#/components/schemas/DirectRecursiveIntersection",
-            },
-            "id": Object {
-              "type": "string",
-            },
+Object {
+  "components": Object {
+    "schemas": Object {
+      "DirectRecursiveIntersection": Object {
+        "properties": Object {
+          "children": Object {
+            "$ref": "#/components/schemas/DirectRecursiveIntersection",
           },
-          "required": Array [
-            "id",
-            "children",
-          ],
-          "type": "object",
-        },
-        "DirectRecursiveType": Object {
-          "properties": Object {
-            "children": Object {
-              "items": Object {
-                "$ref": "#/components/schemas/DirectRecursiveType",
-              },
-              "type": "array",
-            },
-            "id": Object {
-              "type": "string",
-            },
+          "id": Object {
+            "type": "string",
           },
-          "required": Array [
-            "id",
-            "children",
-          ],
-          "type": "object",
         },
-        "DocumentedInterface": Object {
-          "properties": Object {
-            "outputField": Object {
-              "description": "Output field description here",
-              "type": "string",
-            },
-          },
-          "required": Array [
-            "outputField",
-          ],
-          "type": "object",
-        },
-        "IndirectRecursiveType": Object {
-          "properties": Object {
-            "hello": Object {
-              "type": "string",
-            },
+        "required": Array [
+          "id",
+          "children",
+        ],
+        "type": "object",
+      },
+      "DirectRecursiveType": Object {
+        "properties": Object {
+          "children": Object {
             "items": Object {
-              "items": Object {
-                "$ref": "#/components/schemas/MutuallyRecursive",
+              "$ref": "#/components/schemas/DirectRecursiveType",
+            },
+            "type": "array",
+          },
+          "id": Object {
+            "type": "string",
+          },
+        },
+        "required": Array [
+          "id",
+          "children",
+        ],
+        "type": "object",
+      },
+      "DocumentedInterface": Object {
+        "properties": Object {
+          "outputField": Object {
+            "description": "Output field description here",
+            "type": "string",
+          },
+        },
+        "required": Array [
+          "outputField",
+        ],
+        "type": "object",
+      },
+      "IndirectRecursiveType": Object {
+        "properties": Object {
+          "hello": Object {
+            "type": "string",
+          },
+          "items": Object {
+            "items": Object {
+              "$ref": "#/components/schemas/MutuallyRecursive",
+            },
+            "type": "array",
+          },
+        },
+        "required": Array [
+          "hello",
+          "items",
+        ],
+        "type": "object",
+      },
+      "MutuallyRecursive": Object {
+        "properties": Object {
+          "other": Object {
+            "$ref": "#/components/schemas/IndirectRecursiveType",
+          },
+        },
+        "required": Array [
+          "other",
+        ],
+        "type": "object",
+      },
+      "User": Object {
+        "properties": Object {
+          "petName": Object {
+            "nullable": true,
+            "type": "string",
+          },
+          "shoeSize": Object {
+            "type": "number",
+          },
+          "updated": Object {
+            "format": "date-time",
+            "type": "string",
+          },
+        },
+        "required": Array [
+          "shoeSize",
+          "petName",
+          "updated",
+        ],
+        "type": "object",
+      },
+      "User2": Object {
+        "properties": Object {
+          "name": Object {
+            "type": "string",
+          },
+        },
+        "required": Array [
+          "name",
+        ],
+        "type": "object",
+      },
+    },
+  },
+  "paths": Object {
+    "/binary-response": Object {
+      "get": Object {
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "application/octet-stream": Object {
+                "schema": Object {
+                  "format": "binary",
+                  "type": "string",
+                },
               },
-              "type": "array",
             },
+            "description": "OK",
           },
-          "required": Array [
-            "hello",
-            "items",
-          ],
-          "type": "object",
-        },
-        "MutuallyRecursive": Object {
-          "properties": Object {
-            "other": Object {
-              "$ref": "#/components/schemas/IndirectRecursiveType",
-            },
-          },
-          "required": Array [
-            "other",
-          ],
-          "type": "object",
-        },
-        "User": Object {
-          "properties": Object {
-            "petName": Object {
-              "nullable": true,
-              "type": "string",
-            },
-            "shoeSize": Object {
-              "type": "number",
-            },
-            "updated": Object {
-              "format": "date-time",
-              "type": "string",
-            },
-          },
-          "required": Array [
-            "shoeSize",
-            "petName",
-            "updated",
-          ],
-          "type": "object",
-        },
-        "User2": Object {
-          "properties": Object {
-            "name": Object {
-              "type": "string",
-            },
-          },
-          "required": Array [
-            "name",
-          ],
-          "type": "object",
         },
       },
     },
-    "fileName": "tests/test-routes.ts",
-    "paths": Object {
-      "/binary-response": Object {
-        "get": Object {
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "application/octet-stream": Object {
-                  "schema": Object {
-                    "format": "binary",
+    "/branded-request-body": Object {
+      "post": Object {
+        "requestBody": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "properties": Object {
+                  "int": Object {
+                    "type": "integer",
+                  },
+                  "nonEmptyString": Object {
                     "type": "string",
                   },
                 },
+                "required": Array [
+                  "int",
+                  "nonEmptyString",
+                ],
+                "type": "object",
               },
-              "description": "OK",
             },
           },
         },
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "number",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "description": "Bad Request",
+          },
+        },
       },
-      "/branded-request-body": Object {
-        "post": Object {
-          "requestBody": Object {
+    },
+    "/constant": Object {
+      "get": Object {
+        "description": "No input, static output, has a tag",
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "description": "Successful result",
+          },
+        },
+        "summary": "This is a summary",
+        "tags": Array [
+          "Tag",
+        ],
+      },
+    },
+    "/cookies": Object {
+      "get": Object {
+        "parameters": Array [
+          Object {
+            "in": "cookie",
+            "name": "foo",
+            "required": true,
+          },
+          Object {
+            "in": "cookie",
+            "name": "bar",
+            "required": false,
+          },
+        ],
+        "responses": Object {
+          "200": Object {
             "content": Object {
               "application/json": Object {
                 "schema": Object {
                   "properties": Object {
-                    "int": Object {
-                      "type": "integer",
+                    "bar": Object {
+                      "type": "number",
                     },
-                    "nonEmptyString": Object {
+                    "foo": Object {
                       "type": "string",
                     },
                   },
                   "required": Array [
-                    "int",
-                    "nonEmptyString",
+                    "foo",
                   ],
                   "type": "object",
                 },
               },
             },
+            "description": "OK",
           },
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
+          "400": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "description": "Bad Request",
+          },
+        },
+      },
+    },
+    "/direct-route-call": Object {
+      "get": Object {
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "description": "OK",
+          },
+        },
+      },
+    },
+    "/handler-not-inline": Object {
+      "post": Object {
+        "requestBody": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "properties": Object {
+                  "foo": Object {
+                    "type": "string",
+                  },
+                },
+                "required": Array [
+                  "foo",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "description": "Bad Request",
+          },
+        },
+      },
+    },
+    "/interface-array-response": Object {
+      "get": Object {
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "items": Object {
+                    "$ref": "#/components/schemas/User",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+            "description": "OK",
+          },
+        },
+      },
+    },
+    "/interface-response": Object {
+      "get": Object {
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "$ref": "#/components/schemas/User",
+                },
+              },
+            },
+            "description": "OK",
+          },
+        },
+      },
+    },
+    "/no-explicit-route-type": Object {
+      "get": Object {
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "description": "OK",
+          },
+        },
+      },
+    },
+    "/other-file-default-export": Object {
+      "get": Object {
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "description": "OK",
+          },
+        },
+      },
+    },
+    "/other-file-export": Object {
+      "get": Object {
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "$ref": "#/components/schemas/User2",
+                },
+              },
+            },
+            "description": "OK",
+          },
+        },
+      },
+    },
+    "/other-route": Object {
+      "get": Object {
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "description": "OK",
+          },
+        },
+      },
+    },
+    "/query": Object {
+      "get": Object {
+        "parameters": Array [
+          Object {
+            "in": "query",
+            "name": "str",
+            "required": true,
+          },
+          Object {
+            "in": "query",
+            "name": "num",
+            "required": false,
+          },
+        ],
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "description": "Bad Request",
+          },
+        },
+      },
+    },
+    "/recursive-types": Object {
+      "get": Object {
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "$ref": "#/components/schemas/IndirectRecursiveType",
+                },
+              },
+            },
+            "description": "OK",
+          },
+        },
+      },
+    },
+    "/request-body": Object {
+      "post": Object {
+        "description": "This one has request body and two possible successful responses and multiple tags",
+        "requestBody": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "properties": Object {
+                  "date": Object {
+                    "format": "date-time",
+                    "type": "string",
+                  },
+                  "nullableNum": Object {
+                    "nullable": true,
                     "type": "number",
                   },
-                },
-              },
-              "description": "OK",
-            },
-            "400": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "description": "Bad Request",
-            },
-          },
-        },
-      },
-      "/constant": Object {
-        "get": Object {
-          "description": "No input, static output, has a tag",
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "description": "Successful result",
-            },
-          },
-          "summary": "This is a summary",
-          "tags": Array [
-            "Tag",
-          ],
-        },
-      },
-      "/cookies": Object {
-        "get": Object {
-          "parameters": Array [
-            Object {
-              "in": "cookie",
-              "name": "foo",
-              "required": true,
-            },
-            Object {
-              "in": "cookie",
-              "name": "bar",
-              "required": false,
-            },
-          ],
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "application/json": Object {
-                  "schema": Object {
+                  "nullableObj": Object {
+                    "nullable": true,
                     "properties": Object {
-                      "bar": Object {
-                        "type": "number",
-                      },
                       "foo": Object {
-                        "type": "string",
+                        "type": "number",
                       },
                     },
                     "required": Array [
@@ -242,42 +497,158 @@ Array [
                     ],
                     "type": "object",
                   },
-                },
-              },
-              "description": "OK",
-            },
-            "400": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
+                  "numLit": Object {
+                    "enum": Array [
+                      42,
+                    ],
+                    "type": "number",
+                  },
+                  "numLits": Object {
+                    "enum": Array [
+                      42,
+                      123,
+                    ],
+                    "type": "number",
+                  },
+                  "optionalBool": Object {
+                    "type": "boolean",
+                  },
+                  "requiredBool": Object {
+                    "type": "boolean",
+                  },
+                  "str": Object {
+                    "type": "string",
+                  },
+                  "strLit": Object {
+                    "enum": Array [
+                      "foo",
+                    ],
+                    "type": "string",
+                  },
+                  "strLits": Object {
+                    "enum": Array [
+                      "foo",
+                      "bar",
+                    ],
                     "type": "string",
                   },
                 },
+                "required": Array [
+                  "str",
+                  "requiredBool",
+                  "nullableNum",
+                  "nullableObj",
+                  "numLit",
+                  "numLits",
+                  "strLit",
+                  "strLits",
+                  "date",
+                ],
+                "type": "object",
               },
-              "description": "Bad Request",
+            },
+          },
+        },
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "description": "Successful result",
+          },
+          "201": Object {
+            "description": "A new resource was created",
+          },
+          "400": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "description": "Validation error",
+          },
+        },
+        "tags": Array [
+          "Tag1",
+          "Tag2",
+          "Tag3",
+          "Tag4",
+          "Tag5",
+        ],
+      },
+    },
+    "/request-headers": Object {
+      "get": Object {
+        "parameters": Array [
+          Object {
+            "in": "header",
+            "name": "API-KEY",
+            "required": true,
+          },
+          Object {
+            "in": "header",
+            "name": "X-Forwarded-For",
+            "required": false,
+          },
+        ],
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "description": "OK",
+          },
+          "400": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "description": "Bad Request",
+          },
+        },
+      },
+    },
+    "/response-headers": Object {
+      "get": Object {
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "description": "OK",
+            "headers": Object {
+              "X-Bar": Object {
+                "required": false,
+              },
+              "X-Foo": Object {
+                "required": true,
+              },
             },
           },
         },
       },
-      "/direct-route-call": Object {
-        "get": Object {
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "description": "OK",
-            },
-          },
-        },
-      },
-      "/handler-not-inline": Object {
-        "post": Object {
-          "requestBody": Object {
+    },
+    "/same-path-route": Object {
+      "get": Object {
+        "responses": Object {
+          "200": Object {
             "content": Object {
               "application/json": Object {
                 "schema": Object {
@@ -293,584 +664,226 @@ Array [
                 },
               },
             },
-          },
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "description": "OK",
-            },
-            "400": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "description": "Bad Request",
-            },
+            "description": "OK",
           },
         },
       },
-      "/interface-array-response": Object {
-        "get": Object {
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "application/json": Object {
-                  "schema": Object {
-                    "items": Object {
-                      "$ref": "#/components/schemas/User",
-                    },
-                    "type": "array",
-                  },
-                },
-              },
-              "description": "OK",
-            },
-          },
-        },
-      },
-      "/interface-response": Object {
-        "get": Object {
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "application/json": Object {
-                  "schema": Object {
-                    "$ref": "#/components/schemas/User",
-                  },
-                },
-              },
-              "description": "OK",
-            },
-          },
-        },
-      },
-      "/no-explicit-route-type": Object {
-        "get": Object {
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "description": "OK",
-            },
-          },
-        },
-      },
-      "/other-file-default-export": Object {
-        "get": Object {
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "description": "OK",
-            },
-          },
-        },
-      },
-      "/other-file-export": Object {
-        "get": Object {
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "application/json": Object {
-                  "schema": Object {
-                    "$ref": "#/components/schemas/User2",
-                  },
-                },
-              },
-              "description": "OK",
-            },
-          },
-        },
-      },
-      "/query": Object {
-        "get": Object {
-          "parameters": Array [
-            Object {
-              "in": "query",
-              "name": "str",
-              "required": true,
-            },
-            Object {
-              "in": "query",
-              "name": "num",
-              "required": false,
-            },
-          ],
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "description": "OK",
-            },
-            "400": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "description": "Bad Request",
-            },
-          },
-        },
-      },
-      "/recursive-types": Object {
-        "get": Object {
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "application/json": Object {
-                  "schema": Object {
-                    "$ref": "#/components/schemas/IndirectRecursiveType",
-                  },
-                },
-              },
-              "description": "OK",
-            },
-          },
-        },
-      },
-      "/request-body": Object {
-        "post": Object {
-          "description": "This one has request body and two possible successful responses and multiple tags",
-          "requestBody": Object {
+      "post": Object {
+        "responses": Object {
+          "200": Object {
             "content": Object {
               "application/json": Object {
                 "schema": Object {
                   "properties": Object {
-                    "date": Object {
-                      "format": "date-time",
-                      "type": "string",
-                    },
-                    "nullableNum": Object {
-                      "nullable": true,
+                    "bar": Object {
                       "type": "number",
-                    },
-                    "nullableObj": Object {
-                      "nullable": true,
-                      "properties": Object {
-                        "foo": Object {
-                          "type": "number",
-                        },
-                      },
-                      "required": Array [
-                        "foo",
-                      ],
-                      "type": "object",
-                    },
-                    "numLit": Object {
-                      "enum": Array [
-                        42,
-                      ],
-                      "type": "number",
-                    },
-                    "numLits": Object {
-                      "enum": Array [
-                        42,
-                        123,
-                      ],
-                      "type": "number",
-                    },
-                    "optionalBool": Object {
-                      "type": "boolean",
-                    },
-                    "requiredBool": Object {
-                      "type": "boolean",
-                    },
-                    "str": Object {
-                      "type": "string",
-                    },
-                    "strLit": Object {
-                      "enum": Array [
-                        "foo",
-                      ],
-                      "type": "string",
-                    },
-                    "strLits": Object {
-                      "enum": Array [
-                        "foo",
-                        "bar",
-                      ],
-                      "type": "string",
                     },
                   },
                   "required": Array [
-                    "str",
-                    "requiredBool",
-                    "nullableNum",
-                    "nullableObj",
-                    "numLit",
-                    "numLits",
-                    "strLit",
-                    "strLits",
-                    "date",
+                    "bar",
                   ],
                   "type": "object",
                 },
               },
             },
-          },
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "description": "Successful result",
-            },
-            "201": Object {
-              "description": "A new resource was created",
-            },
-            "400": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "description": "Validation error",
-            },
-          },
-          "tags": Array [
-            "Tag1",
-            "Tag2",
-            "Tag3",
-            "Tag4",
-            "Tag5",
-          ],
-        },
-      },
-      "/request-headers": Object {
-        "get": Object {
-          "parameters": Array [
-            Object {
-              "in": "header",
-              "name": "API-KEY",
-              "required": true,
-            },
-            Object {
-              "in": "header",
-              "name": "X-Forwarded-For",
-              "required": false,
-            },
-          ],
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "description": "OK",
-            },
-            "400": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "description": "Bad Request",
-            },
+            "description": "OK",
           },
         },
       },
-      "/response-headers": Object {
-        "get": Object {
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
+    },
+    "/schema-docstrings": Object {
+      "get": Object {
+        "parameters": Array [
+          Object {
+            "description": "Foo bar baz",
+            "in": "query",
+            "name": "param",
+            "required": true,
+          },
+        ],
+        "requestBody": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "properties": Object {
+                  "inputField": Object {
+                    "description": "Input field description",
+                    "type": "number",
                   },
                 },
+                "required": Array [
+                  "inputField",
+                ],
+                "type": "object",
               },
-              "description": "OK",
-              "headers": Object {
-                "X-Bar": Object {
-                  "required": false,
-                },
-                "X-Foo": Object {
-                  "required": true,
+            },
+          },
+        },
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "$ref": "#/components/schemas/DocumentedInterface",
                 },
               },
             },
+            "description": "OK",
+          },
+          "400": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "description": "Bad Request",
           },
         },
       },
-      "/same-path-route": Object {
-        "get": Object {
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "application/json": Object {
-                  "schema": Object {
-                    "properties": Object {
-                      "foo": Object {
-                        "type": "string",
-                      },
-                    },
-                    "required": Array [
-                      "foo",
-                    ],
-                    "type": "object",
-                  },
+    },
+    "/type-alias": Object {
+      "get": Object {
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
                 },
               },
-              "description": "OK",
             },
+            "description": "OK",
           },
-        },
-        "post": Object {
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "application/json": Object {
-                  "schema": Object {
-                    "properties": Object {
-                      "bar": Object {
-                        "type": "number",
-                      },
-                    },
-                    "required": Array [
-                      "bar",
-                    ],
-                    "type": "object",
-                  },
+          "400": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
                 },
               },
-              "description": "OK",
             },
+            "description": "Bad Request",
           },
         },
       },
-      "/schema-docstrings": Object {
-        "get": Object {
-          "parameters": Array [
-            Object {
-              "description": "Foo bar baz",
-              "in": "query",
-              "name": "param",
-              "required": true,
+    },
+    "/unused-request": Object {
+      "get": Object {
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
             },
-          ],
-          "requestBody": Object {
+            "description": "OK",
+          },
+        },
+      },
+    },
+    "/user/{id}/{other}": Object {
+      "get": Object {
+        "parameters": Array [
+          Object {
+            "in": "path",
+            "name": "id",
+            "required": true,
+          },
+          Object {
+            "in": "path",
+            "name": "other",
+            "required": true,
+          },
+        ],
+        "responses": Object {
+          "200": Object {
             "content": Object {
               "application/json": Object {
                 "schema": Object {
                   "properties": Object {
-                    "inputField": Object {
-                      "description": "Input field description",
+                    "id": Object {
                       "type": "number",
                     },
-                  },
-                  "required": Array [
-                    "inputField",
-                  ],
-                  "type": "object",
-                },
-              },
-            },
-          },
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "application/json": Object {
-                  "schema": Object {
-                    "$ref": "#/components/schemas/DocumentedInterface",
-                  },
-                },
-              },
-              "description": "OK",
-            },
-            "400": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "description": "Bad Request",
-            },
-          },
-        },
-      },
-      "/type-alias": Object {
-        "get": Object {
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "description": "OK",
-            },
-            "400": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "description": "Bad Request",
-            },
-          },
-        },
-      },
-      "/unused-request": Object {
-        "get": Object {
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "description": "OK",
-            },
-          },
-        },
-      },
-      "/user/{id}/{other}": Object {
-        "get": Object {
-          "parameters": Array [
-            Object {
-              "in": "path",
-              "name": "id",
-              "required": true,
-            },
-            Object {
-              "in": "path",
-              "name": "other",
-              "required": true,
-            },
-          ],
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "application/json": Object {
-                  "schema": Object {
-                    "properties": Object {
-                      "id": Object {
-                        "type": "number",
-                      },
-                      "other": Object {
-                        "type": "string",
-                      },
-                    },
-                    "required": Array [
-                      "id",
-                      "other",
-                    ],
-                    "type": "object",
-                  },
-                },
-              },
-              "description": "OK",
-            },
-          },
-        },
-      },
-      "/uses-custom-route": Object {
-        "get": Object {
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
-                  },
-                },
-              },
-              "description": "OK",
-            },
-          },
-        },
-      },
-      "/with-content-type-middleware": Object {
-        "post": Object {
-          "requestBody": Object {
-            "content": Object {
-              "application/x-www-form-urlencoded": Object {
-                "schema": Object {
-                  "properties": Object {
-                    "a": Object {
+                    "other": Object {
                       "type": "string",
                     },
                   },
                   "required": Array [
-                    "a",
+                    "id",
+                    "other",
                   ],
                   "type": "object",
                 },
               },
             },
+            "description": "OK",
           },
-          "responses": Object {
-            "200": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
+        },
+      },
+    },
+    "/uses-custom-route": Object {
+      "get": Object {
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "description": "OK",
+          },
+        },
+      },
+    },
+    "/with-content-type-middleware": Object {
+      "post": Object {
+        "requestBody": Object {
+          "content": Object {
+            "application/x-www-form-urlencoded": Object {
+              "schema": Object {
+                "properties": Object {
+                  "a": Object {
                     "type": "string",
                   },
                 },
+                "required": Array [
+                  "a",
+                ],
+                "type": "object",
               },
-              "description": "OK",
             },
-            "400": Object {
-              "content": Object {
-                "text/plain": Object {
-                  "schema": Object {
-                    "type": "string",
-                  },
+          },
+        },
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
                 },
               },
-              "description": "Bad Request",
             },
+            "description": "OK",
+          },
+          "400": Object {
+            "content": Object {
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "string",
+                },
+              },
+            },
+            "description": "Bad Request",
           },
         },
       },
     },
   },
-]
+}
 `;

--- a/tests/__snapshots__/generate.spec.ts.snap
+++ b/tests/__snapshots__/generate.spec.ts.snap
@@ -13,6 +13,116 @@ Array [
 exports[`generate works 1`] = `
 Array [
   Object {
+    "components": Object {
+      "schemas": Object {
+        "DirectRecursiveIntersection": Object {
+          "properties": Object {
+            "children": Object {
+              "$ref": "#/components/schemas/DirectRecursiveIntersection",
+            },
+            "id": Object {
+              "type": "string",
+            },
+          },
+          "required": Array [
+            "id",
+            "children",
+          ],
+          "type": "object",
+        },
+        "DirectRecursiveType": Object {
+          "properties": Object {
+            "children": Object {
+              "items": Object {
+                "$ref": "#/components/schemas/DirectRecursiveType",
+              },
+              "type": "array",
+            },
+            "id": Object {
+              "type": "string",
+            },
+          },
+          "required": Array [
+            "id",
+            "children",
+          ],
+          "type": "object",
+        },
+        "DocumentedInterface": Object {
+          "properties": Object {
+            "outputField": Object {
+              "description": "Output field description here",
+              "type": "string",
+            },
+          },
+          "required": Array [
+            "outputField",
+          ],
+          "type": "object",
+        },
+        "IndirectRecursiveType": Object {
+          "properties": Object {
+            "hello": Object {
+              "type": "string",
+            },
+            "items": Object {
+              "items": Object {
+                "$ref": "#/components/schemas/MutuallyRecursive",
+              },
+              "type": "array",
+            },
+          },
+          "required": Array [
+            "hello",
+            "items",
+          ],
+          "type": "object",
+        },
+        "MutuallyRecursive": Object {
+          "properties": Object {
+            "other": Object {
+              "$ref": "#/components/schemas/IndirectRecursiveType",
+            },
+          },
+          "required": Array [
+            "other",
+          ],
+          "type": "object",
+        },
+        "User": Object {
+          "properties": Object {
+            "petName": Object {
+              "nullable": true,
+              "type": "string",
+            },
+            "shoeSize": Object {
+              "type": "number",
+            },
+            "updated": Object {
+              "format": "date-time",
+              "type": "string",
+            },
+          },
+          "required": Array [
+            "shoeSize",
+            "petName",
+            "updated",
+          ],
+          "type": "object",
+        },
+        "User2": Object {
+          "properties": Object {
+            "name": Object {
+              "type": "string",
+            },
+          },
+          "required": Array [
+            "name",
+          ],
+          "type": "object",
+        },
+      },
+    },
     "fileName": "tests/test-routes.ts",
     "paths": Object {
       "/binary-response": Object {
@@ -216,25 +326,7 @@ Array [
                 "application/json": Object {
                   "schema": Object {
                     "items": Object {
-                      "properties": Object {
-                        "petName": Object {
-                          "nullable": true,
-                          "type": "string",
-                        },
-                        "shoeSize": Object {
-                          "type": "number",
-                        },
-                        "updated": Object {
-                          "format": "date-time",
-                          "type": "string",
-                        },
-                      },
-                      "required": Array [
-                        "shoeSize",
-                        "petName",
-                        "updated",
-                      ],
-                      "type": "object",
+                      "$ref": "#/components/schemas/User",
                     },
                     "type": "array",
                   },
@@ -252,25 +344,7 @@ Array [
               "content": Object {
                 "application/json": Object {
                   "schema": Object {
-                    "properties": Object {
-                      "petName": Object {
-                        "nullable": true,
-                        "type": "string",
-                      },
-                      "shoeSize": Object {
-                        "type": "number",
-                      },
-                      "updated": Object {
-                        "format": "date-time",
-                        "type": "string",
-                      },
-                    },
-                    "required": Array [
-                      "shoeSize",
-                      "petName",
-                      "updated",
-                    ],
-                    "type": "object",
+                    "$ref": "#/components/schemas/User",
                   },
                 },
               },
@@ -316,9 +390,9 @@ Array [
           "responses": Object {
             "200": Object {
               "content": Object {
-                "text/plain": Object {
+                "application/json": Object {
                   "schema": Object {
-                    "type": "string",
+                    "$ref": "#/components/schemas/User2",
                   },
                 },
               },
@@ -361,6 +435,22 @@ Array [
                 },
               },
               "description": "Bad Request",
+            },
+          },
+        },
+      },
+      "/recursive-types": Object {
+        "get": Object {
+          "responses": Object {
+            "200": Object {
+              "content": Object {
+                "application/json": Object {
+                  "schema": Object {
+                    "$ref": "#/components/schemas/IndirectRecursiveType",
+                  },
+                },
+              },
+              "description": "OK",
             },
           },
         },
@@ -620,16 +710,7 @@ Array [
               "content": Object {
                 "application/json": Object {
                   "schema": Object {
-                    "properties": Object {
-                      "outputField": Object {
-                        "description": "Output field description here",
-                        "type": "string",
-                      },
-                    },
-                    "required": Array [
-                      "outputField",
-                    ],
-                    "type": "object",
+                    "$ref": "#/components/schemas/DocumentedInterface",
                   },
                 },
               },

--- a/tests/exported-routes.ts
+++ b/tests/exported-routes.ts
@@ -1,9 +1,14 @@
 import { Response, Route, route } from 'typera-express'
 
-export const otherFileExport: Route<Response.Ok<string>> = route
+// This interface also exists in test-routes.ts => it should be named `User2` in component schemas.
+interface User {
+  name: string
+}
+
+export const otherFileExport: Route<Response.Ok<User>> = route
   .get('/other-file-export')
   .handler(async () => {
-    return Response.ok('hello')
+    return Response.ok({ name: 'hello' })
   })
 
 export default route.get('/other-file-default-export').handler(async () => {

--- a/tests/generate.spec.ts
+++ b/tests/generate.spec.ts
@@ -5,11 +5,12 @@ const relativePath = (fileName: string): string =>
   path.relative(process.cwd(), __dirname + '/' + fileName)
 
 const testRoutes = relativePath('test-routes.ts')
+const otherRoutes = relativePath('other-routes.ts')
 const warningRoutes = relativePath('warning-routes.ts')
 
 describe('generate', () => {
   it('works', () => {
-    const result = generate([testRoutes], { strict: true })
+    const result = generate([testRoutes, otherRoutes], { strict: true })
     expect(result).toMatchSnapshot()
   })
 

--- a/tests/middlewares.ts
+++ b/tests/middlewares.ts
@@ -1,5 +1,9 @@
 import { Middleware } from 'typera-express'
 import { urlencoded } from 'body-parser'
+
 export const formUrlEncodedMiddleware = Middleware.wrapNative<
   Record<'contentType', 'application/x-www-form-urlencoded'>
->(urlencoded())
+>(
+  // TODO: typera's typings don't like connect middleware
+  urlencoded() as any
+)

--- a/tests/other-routes.ts
+++ b/tests/other-routes.ts
@@ -1,0 +1,5 @@
+import { Response, route, Route, router } from 'typera-express'
+
+const otherRoute: Route<Response.Ok<string>> = route.get('/other-route').handler(() => Response.ok('hello'))
+
+export default router(otherRoute)

--- a/tests/other-routes.ts
+++ b/tests/other-routes.ts
@@ -1,6 +1,8 @@
 import { Response, route, Route, router } from 'typera-express'
 
-const otherRoute: Route<Response.Ok<string>> = route.get('/other-route').handler(() => Response.ok('hello'))
+const otherRoute: Route<Response.Ok<string>> = route
+  .get('/other-route')
+  .handler(() => Response.ok('hello'))
 
 /** @prefix /other-stuff */
 export default router(otherRoute)

--- a/tests/other-routes.ts
+++ b/tests/other-routes.ts
@@ -2,4 +2,5 @@ import { Response, route, Route, router } from 'typera-express'
 
 const otherRoute: Route<Response.Ok<string>> = route.get('/other-route').handler(() => Response.ok('hello'))
 
+/** @prefix /other-stuff */
 export default router(otherRoute)

--- a/tests/test-routes.ts
+++ b/tests/test-routes.ts
@@ -273,6 +273,32 @@ const withContentTypeMiddleware: Route<
     return Response.ok(request.body.a)
   })
 
+interface DirectRecursiveType {
+  id: string
+  children: DirectRecursiveType[]
+}
+
+type DirectRecursiveIntersection = { id: string } & {
+  children: DirectRecursiveIntersection
+}
+
+interface IndirectRecursiveType {
+  hello: string
+  items: MutuallyRecursive[]
+}
+
+interface MutuallyRecursive {
+  other: IndirectRecursiveType
+}
+
+const recursiveTypes: Route<
+  | Response.Ok<DirectRecursiveType>
+  | Response.Ok<DirectRecursiveIntersection>
+  | Response.Ok<IndirectRecursiveType>
+> = route.get('/recursive-types').handler(async () => {
+  return Response.ok({ id: 'hell', children: [] })
+})
+
 export default router(
   constant,
   directRouteCall,
@@ -295,6 +321,7 @@ export default router(
   handlerNotInline,
   typeAlias,
   withContentTypeMiddleware,
+  recursiveTypes,
   otherFileExport, // export from another module
   otherFileDefaultExport // default export from another module
 )

--- a/tests/test-routes.ts
+++ b/tests/test-routes.ts
@@ -278,7 +278,7 @@ interface DirectRecursiveType {
   children: DirectRecursiveType[]
 }
 
-type DirectRecursiveIntersection = { id: string } & {
+type DirectRecursiveIntersection = { id: string } & {
   children: DirectRecursiveIntersection
 }
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "noEmit": false,
+    "declaration": true
+  },
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "target": "es6",
     "lib": ["es2019"],
+    "skipLibCheck": true,
     "strict": true,
     "declaration": true
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,10 @@
 {
   "compilerOptions": {
-    "outDir": "dist",
+    "noEmit": true,
     "module": "commonjs",
     "target": "es6",
     "lib": ["es2019"],
     "skipLibCheck": true,
-    "strict": true,
-    "declaration": true
-  },
-  "include": ["src/*.ts"],
-  "exclude": []
+    "strict": true
+  }
 }


### PR DESCRIPTION
- Generate output to a single file, adjust CLI options accordingly
- Generate reusable schemas from interfaces and type aliases under `components`
- Refer to reusable schemas with `"$ref": "#/components/schemas/MyType"`
- Remove the `prefix()` function, use the `@prefix` JSDoc comment on the `router()` call instead
- Don't crash on recursively defined types anymore

See docs/upgrading.md for upgrading instructions.