### PR TITLE
Add schema to req param and res header objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "yargs": "^17.0.0"
   },
   "devDependencies": {
+    "@apidevtools/swagger-parser": "^10.0.3",
     "@types/jest": "^27.0.1",
     "@types/node": "*",
     "@types/statuses": "^2.0.0",

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -195,10 +195,10 @@ const getRouteDeclaration = (
       : undefined
 
   const parameters = [
-    ...typeToParameters(ctx, 'path', routeParams),
-    ...typeToParameters(ctx, 'query', query),
-    ...typeToParameters(ctx, 'header', headers),
-    ...typeToParameters(ctx, 'cookie', cookies),
+    ...typeToRequestParameters(ctx, 'path', routeParams),
+    ...typeToRequestParameters(ctx, 'query', query),
+    ...typeToRequestParameters(ctx, 'header', headers),
+    ...typeToRequestParameters(ctx, 'cookie', cookies),
   ]
 
   const pathTemplate = path.replace(/:([^-.()/]+)(\(.*?\))?/g, '{$1}')
@@ -568,7 +568,7 @@ const getResponseDefinition = (
   }
 
   const headers = !isUndefinedType(headersType)
-    ? typeToHeaders(ctx, headersType)
+    ? typeToResponseHeaders(ctx, headersType)
     : undefined
 
   let description = responseDescriptions[status]
@@ -603,7 +603,7 @@ const getResponseDefinition = (
   }
 }
 
-const typeToParameters = (
+const typeToRequestParameters = (
   ctx: Context,
   in_: 'path' | 'query' | 'header' | 'cookie',
   type: ts.Type | undefined
@@ -617,6 +617,7 @@ const typeToParameters = (
       name: prop.name,
       in: in_,
       required: in_ === 'path' ? true : !isOptional(prop),
+      schema: { type: 'string' },
       ...(description ? { description } : undefined),
     }
   })
@@ -626,11 +627,12 @@ interface Headers {
   [header: string]: OpenAPIV3.HeaderObject
 }
 
-const typeToHeaders = (ctx: Context, type: ts.Type): Headers => {
+const typeToResponseHeaders = (ctx: Context, type: ts.Type): Headers => {
   const result: Headers = {}
   const props = ctx.checker.getPropertiesOfType(type)
   props.forEach((prop) => {
     result[prop.name] = {
+      schema: { type: 'string' },
       required: !isOptional(prop),
     }
   })

--- a/tests/__snapshots__/generate.spec.ts.snap
+++ b/tests/__snapshots__/generate.spec.ts.snap
@@ -215,11 +215,17 @@ Object {
             "in": "cookie",
             "name": "foo",
             "required": true,
+            "schema": Object {
+              "type": "string",
+            },
           },
           Object {
             "in": "cookie",
             "name": "bar",
             "required": false,
+            "schema": Object {
+              "type": "string",
+            },
           },
         ],
         "responses": Object {
@@ -422,11 +428,17 @@ Object {
             "in": "query",
             "name": "str",
             "required": true,
+            "schema": Object {
+              "type": "string",
+            },
           },
           Object {
             "in": "query",
             "name": "num",
             "required": false,
+            "schema": Object {
+              "type": "string",
+            },
           },
         ],
         "responses": Object {
@@ -590,11 +602,17 @@ Object {
             "in": "header",
             "name": "API-KEY",
             "required": true,
+            "schema": Object {
+              "type": "string",
+            },
           },
           Object {
             "in": "header",
             "name": "X-Forwarded-For",
             "required": false,
+            "schema": Object {
+              "type": "string",
+            },
           },
         ],
         "responses": Object {
@@ -636,9 +654,15 @@ Object {
             "headers": Object {
               "X-Bar": Object {
                 "required": false,
+                "schema": Object {
+                  "type": "string",
+                },
               },
               "X-Foo": Object {
                 "required": true,
+                "schema": Object {
+                  "type": "string",
+                },
               },
             },
           },
@@ -699,6 +723,9 @@ Object {
             "in": "query",
             "name": "param",
             "required": true,
+            "schema": Object {
+              "type": "string",
+            },
           },
         ],
         "requestBody": Object {
@@ -792,11 +819,17 @@ Object {
             "in": "path",
             "name": "id",
             "required": true,
+            "schema": Object {
+              "type": "string",
+            },
           },
           Object {
             "in": "path",
             "name": "other",
             "required": true,
+            "schema": Object {
+              "type": "string",
+            },
           },
         ],
         "responses": Object {

--- a/tests/generate.spec.ts
+++ b/tests/generate.spec.ts
@@ -1,4 +1,5 @@
 import * as path from 'path'
+import * as SwaggerParser from '@apidevtools/swagger-parser'
 import { LogLevel, generate } from '../src/index'
 
 const relativePath = (fileName: string): string =>
@@ -9,10 +10,24 @@ const otherRoutes = relativePath('other-routes.ts')
 const warningRoutes = relativePath('warning-routes.ts')
 
 describe('generate', () => {
-  it('works', () => {
+  it('works', async () => {
     const { output, unseenFileNames } = generate([testRoutes, otherRoutes], {
       strict: true,
     })
+
+    // - Throws if output is invalid
+    // - Mutates the input if passed as an object (!), so round-trip through JSON first
+    await SwaggerParser.validate(
+      JSON.parse(
+        JSON.stringify({
+          openapi: '3.0.0',
+          info: { title: 'test', version: '1' },
+          ...output,
+        })
+      ),
+      { resolve: { external: false } }
+    )
+
     expect(output).toMatchSnapshot()
     expect(unseenFileNames).toEqual([])
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,38 @@
 # yarn lockfile v1
 
 
+"@apidevtools/json-schema-ref-parser@^9.0.6":
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz#d720f9256e3609621280584f2b47ae165359268b"
+  integrity sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==
+  dependencies:
+    "@jsdevtools/ono" "^7.1.3"
+    "@types/json-schema" "^7.0.6"
+    call-me-maybe "^1.0.1"
+    js-yaml "^4.1.0"
+
+"@apidevtools/openapi-schemas@^2.0.4":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz#9fa08017fb59d80538812f03fc7cac5992caaa17"
+  integrity sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==
+
+"@apidevtools/swagger-methods@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz#b789a362e055b0340d04712eafe7027ddc1ac267"
+  integrity sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==
+
+"@apidevtools/swagger-parser@^10.0.3":
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz#32057ae99487872c4dd96b314a1ab4b95d89eaf5"
+  integrity sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==
+  dependencies:
+    "@apidevtools/json-schema-ref-parser" "^9.0.6"
+    "@apidevtools/openapi-schemas" "^2.0.4"
+    "@apidevtools/swagger-methods" "^3.0.2"
+    "@jsdevtools/ono" "^7.1.3"
+    call-me-maybe "^1.0.1"
+    z-schema "^5.0.1"
+
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
@@ -881,6 +913,11 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@jsdevtools/ono@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
+  integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
+
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
@@ -1050,6 +1087,11 @@
   dependencies:
     jest-matcher-utils "^27.0.0"
     pretty-format "^27.0.0"
+
+"@types/json-schema@^7.0.6":
+  version "7.0.10"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.10.tgz#9b05b7896166cd00e9cbd59864853abf65d9ac23"
+  integrity sha512-BLO9bBq59vW3fxCpD4o0N4U+DXsvwvIcl+jofw0frQo/GrBFC+/jRZj1E7kgp6dvTyNmA4y6JCV5Id/r3mNP5A==
 
 "@types/json-schema@^7.0.7":
   version "7.0.7"
@@ -1312,6 +1354,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -1490,6 +1537,11 @@ bytes@3.1.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
+call-me-maybe@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
+  integrity sha1-JtII6onje1y95gJQoV8DHBak1ms=
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -1621,6 +1673,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^2.7.1:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -3076,6 +3133,13 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
 jsdom@^16.6.0:
   version "16.6.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.6.0.tgz#f79b3786682065492a3da6a60a4695da983805ac"
@@ -3183,6 +3247,16 @@ lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
 lodash.memoize@4.x:
   version "4.1.2"
@@ -4253,6 +4327,11 @@ v8-to-istanbul@^8.1.0:
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
 
+validator@^13.7.0:
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
+  integrity sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
@@ -4447,3 +4526,14 @@ yargs@^17.0.0:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
+
+z-schema@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/z-schema/-/z-schema-5.0.2.tgz#f410394b2c9fcb9edaf6a7511491c0bb4e89a504"
+  integrity sha512-40TH47ukMHq5HrzkeVE40Ad7eIDKaRV2b+Qpi2prLc9X9eFJFzV7tMe5aH12e6avaSS/u5l653EQOv+J9PirPw==
+  dependencies:
+    lodash.get "^4.4.2"
+    lodash.isequal "^4.5.0"
+    validator "^13.7.0"
+  optionalDependencies:
+    commander "^2.7.1"


### PR DESCRIPTION
This makes the generated OpenAPI document valid. Issues were found by adding validation of the generated document to unit tests (via @apidevtools/swagger-parser).