### PR TITLE
feat: add support for route operationId

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -174,6 +174,8 @@ const getRouteDeclaration = (
   const summary = getRouteSummary(symbol)
   const tags = getSymbolTags(symbol)
   const routeInput = getRouteInput(ctx, symbol)
+  const operationId = getRouteOperationId(symbol)
+
   if (!routeInput) {
     ctx.log('warn', `Could not determine route input for symbol ${symbol.name}`)
     return
@@ -217,6 +219,7 @@ const getRouteDeclaration = (
     method,
     {
       ...(summary ? { summary } : undefined),
+      ...(operationId ? { operationId } : undefined),
       ...(description ? { description } : undefined),
       ...(tags && tags.length > 0 ? { tags } : undefined),
       ...(parameters.length > 0 ? { parameters } : undefined),
@@ -248,6 +251,14 @@ const getSymbolTags = (symbol: ts.Symbol): string[] | undefined =>
     .filter(isDefined)
     .flatMap((symbolDisplayPart) => symbolDisplayPart.text.split(','))
     .map((tag) => tag.trim())
+
+const getRouteOperationId = (symbol: ts.Symbol): string | undefined =>
+  symbol
+    .getJsDocTags()
+    .filter((tag) => tag.name === 'operationId')
+    .flatMap((tag) => tag.text)
+    .filter(isDefined)
+    .map((symbolDisplayPart) => symbolDisplayPart.text)[0]
 
 const getNodeTags = (node: ts.Node): string[] =>
   ts

--- a/tests/__snapshots__/generate.spec.ts.snap
+++ b/tests/__snapshots__/generate.spec.ts.snap
@@ -190,6 +190,7 @@ Object {
     "/constant": Object {
       "get": Object {
         "description": "No input, static output, has a tag",
+        "operationId": "getConstant",
         "responses": Object {
           "200": Object {
             "content": Object {

--- a/tests/test-routes.ts
+++ b/tests/test-routes.ts
@@ -21,6 +21,7 @@ import { formUrlEncodedMiddleware } from './middlewares'
  *
  * @tags Tag
  * @summary This is a summary
+ * @operationId getConstant
  * @response 200 Successful result
  */
 const constant: Route<Response.Ok<string>> = route


### PR DESCRIPTION
## Why?
This PR deals with issue reported in #528.

## How?
As suggested by @akheron at https://github.com/akheron/typera-openapi/issues/528#issuecomment-1298061341 PR reads operationId from JSDoc of the route.