### PR TITLE
Check operationId duplication over all input files

### DIFF
--- a/tests/__snapshots__/generate.spec.ts.snap
+++ b/tests/__snapshots__/generate.spec.ts.snap
@@ -5,7 +5,7 @@ Array [
   Object {
     "level": "warn",
     "location": "tests/duplicated-operation-ids-routes.ts:22:0",
-    "message": "Duplicated operationId routeOne",
+    "message": "Duplicated operationId routeOne. Use @operationId in JSDoc comment to override.",
   },
 ]
 `;


### PR DESCRIPTION
While at it, tweak the warning message a bit, too.