### PR TITLE
Handle multiple responses for same status code

### DIFF
--- a/tests/__snapshots__/generate.spec.ts.snap
+++ b/tests/__snapshots__/generate.spec.ts.snap
@@ -133,6 +133,86 @@ Object {
     },
   },
   "paths": Object {
+    "/any-of": Object {
+      "get": Object {
+        "operationId": "anyOf",
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "oneOf": Array [
+                    Object {
+                      "properties": Object {
+                        "status": Object {
+                          "enum": Array [
+                            "success",
+                          ],
+                          "type": "string",
+                        },
+                      },
+                      "required": Array [
+                        "status",
+                      ],
+                      "type": "object",
+                    },
+                    Object {
+                      "properties": Object {
+                        "errorCode": Object {
+                          "type": "string",
+                        },
+                        "status": Object {
+                          "enum": Array [
+                            "error",
+                          ],
+                          "type": "string",
+                        },
+                      },
+                      "required": Array [
+                        "status",
+                        "errorCode",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              },
+            },
+            "description": "OK",
+          },
+        },
+      },
+    },
+    "/any-of-content-types": Object {
+      "get": Object {
+        "operationId": "anyOfContentTypes",
+        "responses": Object {
+          "200": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "properties": Object {
+                    "foo": Object {
+                      "type": "string",
+                    },
+                  },
+                  "required": Array [
+                    "foo",
+                  ],
+                  "type": "object",
+                },
+              },
+              "text/plain": Object {
+                "schema": Object {
+                  "type": "number",
+                },
+              },
+            },
+            "description": "OK",
+          },
+        },
+      },
+    },
     "/binary-response": Object {
       "get": Object {
         "operationId": "binaryResponse",
@@ -545,7 +625,17 @@ Object {
             "content": Object {
               "application/json": Object {
                 "schema": Object {
-                  "$ref": "#/components/schemas/IndirectRecursiveType",
+                  "oneOf": Array [
+                    Object {
+                      "$ref": "#/components/schemas/DirectRecursiveType",
+                    },
+                    Object {
+                      "$ref": "#/components/schemas/DirectRecursiveIntersection",
+                    },
+                    Object {
+                      "$ref": "#/components/schemas/IndirectRecursiveType",
+                    },
+                  ],
                 },
               },
             },

--- a/tests/test-routes.ts
+++ b/tests/test-routes.ts
@@ -30,6 +30,22 @@ const constant: Route<Response.Ok<string>> = route
     return Response.ok('bar')
   })
 
+const anyOf: Route<
+  | Response.Ok<{ status: 'success' }>
+  | Response.Ok<{ status: 'error'; errorCode: string }>
+> = route.get('/any-of').handler(async () => {
+  return (
+    Response.ok({ status: 'success' }) ||
+    Response.ok({ status: 'error', errorCode: 'foo' })
+  )
+})
+
+const anyOfContentTypes: Route<
+  Response.Ok<{ foo: string }> | Response.Ok<number>
+> = route.get('/any-of-content-types').handler(async () => {
+  return Response.ok({ foo: 'bar' }) || Response.ok(42)
+})
+
 // Direct route() call
 const directRouteCall: Route<Response.Ok<string>> = route(
   'get',
@@ -332,6 +348,8 @@ const customContentType: Route<
 
 export default router(
   constant,
+  anyOf,
+  anyOfContentTypes,
   directRouteCall,
   requestBody,
   interfaceResponse,


### PR DESCRIPTION
Previously the OpenAPI schema generated would only have the last member of the union as a
possible response type as it was expected that a status code would have only one possible response.